### PR TITLE
Automatically fill transactionId

### DIFF
--- a/src/Omnipay/TargetPay/Message/CompletePurchaseRequest.php
+++ b/src/Omnipay/TargetPay/Message/CompletePurchaseRequest.php
@@ -19,6 +19,10 @@ abstract class CompletePurchaseRequest extends AbstractRequest
      */
     public function getData()
     {
+        if(!$this->getTransactionId() && $trixId = $this->httpRequest->query->get('trxid')){
+            $this->setTransactionId($trixId);
+        }
+        
         $this->validate('transactionId');
 
         return array(


### PR DESCRIPTION
I don't know what the 'common' way to do this in Omnipay, but shouldn't the transactionId be set from the request? Or how should you do it?
See this example, that also uses the request data: https://github.com/omnipay/paypal/blob/master/src/Omnipay/PayPal/Message/ExpressCompleteAuthorizeRequest.php

This commit should check if the transactionId is not set, and only when the get value is not null/false, set the transactionId. So it should not break existing behavior.
