### PR TITLE
Get transactionReference from current request

### DIFF
--- a/src/Omnipay/TargetPay/Message/CompletePurchaseRequest.php
+++ b/src/Omnipay/TargetPay/Message/CompletePurchaseRequest.php
@@ -19,11 +19,9 @@ abstract class CompletePurchaseRequest extends AbstractRequest
      */
     public function getData()
     {
-        $this->validate('transactionId');
-
         return array(
             'rtlo' => $this->getSubAccountId(),
-            'trxid' => $this->getTransactionId(),
+            'trxid' => $this->httpRequest->query->get('trxid'),
             'once' => $this->getExchangeOnce(),
             'test' => $this->getTestMode(),
         );

--- a/tests/Omnipay/TargetPay/Message/CompletePurchaseRequestTest.php
+++ b/tests/Omnipay/TargetPay/Message/CompletePurchaseRequestTest.php
@@ -14,10 +14,12 @@ class CompletePurchaseRequestTest extends TestCase
 
     protected function setUp()
     {
-        $arguments = array($this->getHttpClient(), $this->getHttpRequest());
+        $request = $this->getHttpRequest();
+        $request->query->set('trxid', '123456');
+
+        $arguments = array($this->getHttpClient(), $request);
         $this->request = m::mock('Omnipay\TargetPay\Message\CompletePurchaseRequest[getEndpoint]', $arguments);
         $this->request->shouldReceive('getEndpoint')->andReturn('http://localhost');
-        $this->request->setTransactionId('123456');
     }
 
     public function testData()


### PR DESCRIPTION
Instead of transactionId, because trxid is the transactionReference instead of transactionId, in Omnipay context.
Fixes #1
